### PR TITLE
fix: make link.exe find PyPy's `python*.lib`

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -90880,6 +90880,10 @@ function findPyPyVersion(versionSpec, architecture, updateEnvironment, checkLate
             // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
             core.exportVariable('Python3_ROOT_DIR', installDir);
             core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
+            // https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#link-environment-variables
+            if (utils_1.IS_WINDOWS) {
+                core.exportVariable('LIB', pythonLocation + '/libs');
+            }
             core.addPath(pythonLocation);
             core.addPath(_binDir);
         }

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -93,6 +93,10 @@ export async function findPyPyVersion(
     // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
     core.exportVariable('Python3_ROOT_DIR', installDir);
     core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
+    // https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#link-environment-variables
+    if (IS_WINDOWS) {
+      core.exportVariable('LIB', pythonLocation + '/libs');
+    }
     core.addPath(pythonLocation);
     core.addPath(_binDir);
   }


### PR DESCRIPTION
Point `LIB` environment variable to `libs` directory of extracted PyPy on Windows, so that `link.exe` find it while building Python extensions: https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#link-environment-variables

Add a test for building Python extension.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.